### PR TITLE
Link the native image binary to musl

### DIFF
--- a/code/spring-boot-telemetry/Dockerfile
+++ b/code/spring-boot-telemetry/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/graalvm/native-image AS build
+FROM ghcr.io/graalvm/native-image-community:22-muslib AS build
 WORKDIR /
 # install maven
 RUN curl https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz | tar zx
@@ -9,8 +9,7 @@ COPY src src
 # compile the native image
 RUN --mount=type=cache,target=/root/.m2 /apache-maven-3.9.6/bin/mvn clean native:compile -Pnative
 
-
-FROM ubuntu:22.04
+FROM alpine
 EXPOSE 8080
 COPY --from=build /app/target/spring-boot-telemetry .
-CMD ["./spring-boot-telemetry"]
+CMD sleep 3 ; exec ./spring-boot-telemetry

--- a/code/spring-boot-telemetry/pom.xml
+++ b/code/spring-boot-telemetry/pom.xml
@@ -57,6 +57,11 @@
       <plugin>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
+        <configuration>
+          <buildArgs>
+            <buildArg>--libc=musl</buildArg>
+          </buildArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Using musl means that the native image binary can run in Alpine. I also tried to generate a static binary, but it didn't work for reasons that are beyond my understanding 😅