### PR TITLE
Type mismatch in VeggieController.java

### DIFF
--- a/code/spring-boot-telemetry/src/main/java/com/azure/examples/springboot/controller/VeggieController.java
+++ b/code/spring-boot-telemetry/src/main/java/com/azure/examples/springboot/controller/VeggieController.java
@@ -48,7 +48,7 @@ public class VeggieController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteVeggie(@PathVariable("id") Long id) {
+    public ResponseEntity<String> deleteVeggie(@PathVariable("id") String id) {
         veggieService.deleteVeggie(id);
         return ResponseEntity.ok("Veggie deleted successfully");
     }
@@ -60,7 +60,7 @@ public class VeggieController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<VeggieItem> getVeggieById(@PathVariable("id") Long id) {
+    public ResponseEntity<VeggieItem> getVeggieById(@PathVariable("id") String id) {
         VeggieItem veggie = veggieService.getVeggieById(id);
         if (veggie != null) {
             return ResponseEntity.ok(veggie);


### PR DESCRIPTION
There is a type mismatch in VeggieController.java.
The field "id" is defined with String in Veggie.java, while a parameter in methods "deleteVeggie" and "getVeggieById" is defined with Long. If this mismatch is not fixed, both methods always return 400 (Bad request).